### PR TITLE
Specify a commit hash for the jsdoc-baseline package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "eslint-plugin-promise": "^3.5.0",
         "eslint-plugin-standard": "^3.0.1",
         "jsdoc": "^3.5.5",
-        "jsdoc-baseline": "https://github.com/hegemonic/baseline/tarball/master",
+        "jsdoc-baseline": "https://github.com/hegemonic/baseline/tarball/222e13a",
         "nyc": "^11.0.3",
         "winston": "2.2.0"
     }


### PR DESCRIPTION
I plan to make breaking changes to the hegemonic/jsdoc-baseline repo. To ensure that your repo is not affected by these breaking changes, this pull request pins the `jsdoc-baseline` package to a specific commit hash.

If you prefer, you can use the [NPM release of this package](https://www.npmjs.com/package/jsdoc-baseline) instead by setting the `jsdoc-baseline` property to `^0.1.1`.